### PR TITLE
Enable access to debugging helpers via global.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,4 +22,10 @@ module.exports = {
       }
     };
   },
+
+  included() {
+    this._super.included.apply(this, arguments);
+
+    this.import('vendor/ember-template-invocation-location/index.js');
+  },
 };

--- a/tests/integration/components/index-test.js
+++ b/tests/integration/components/index-test.js
@@ -66,5 +66,22 @@ module('Integration | Component | index', function(hooks) {
 
       await render(hbs('some-stuff \n\n other stuff {{foo-bar}}', { moduleName: 'app/templates/bar.hbs' }));
     });
+
+    test('can access simplified stack from global (without modifying source helper/component/modifier)', async function(assert) {
+      assert.expect(1);
+
+      this.owner.register('template:components/foo-bar', hbs('\n {{invoke-me}}', { moduleName: 'app/templates/components/foo-bar.hbs' }));
+
+      this.owner.register('helper:invoke-me', helper((params, hash) => {
+        let stack = self._templateInvocationInfo.getInvocationStack(hash);
+
+        assert.deepEqual(stack, [
+          'app/templates/components/foo-bar.hbs @ L2:C1',
+          'app/templates/bar.hbs @ L3:C13'
+        ]);
+      }));
+
+      await render(hbs('some-stuff \n\n other stuff {{foo-bar}}', { moduleName: 'app/templates/bar.hbs' }));
+    });
   });
 });

--- a/vendor/ember-template-invocation-location/index.js
+++ b/vendor/ember-template-invocation-location/index.js
@@ -1,0 +1,10 @@
+(function() {
+  Object.defineProperty(self, '_templateInvocationInfo', {
+    enumerable: false,
+    configurable: true,
+
+    get() {
+      return require('ember-template-invocation-location');
+    }
+  });
+})();


### PR DESCRIPTION
This allows someone to determine the template invocation stack while locally debugging, without having to add an import at the callsite to get access to the debugging tools.

E.g. from within a breakpoint in a component's `didInsertElement`, you could do:

```js
didInsertElement() {
  console.log(_templateInvocationInfo.getInvocationStack(this).join('\n'));
}
```

And have something like this printed out:

```
app-name/templates/components/foo-bar.hbs @ L2:C1
app-name/templates/bar.hbs @ L3:C13
```