### PR TITLE
Avoid mutating built-in keywords.

### DIFF
--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -1,15 +1,34 @@
 const LOCATION_PROPERTY = 'debugTemplateInvocationSite'; // must match addon/index.js value
+const BUILTINS = ['yield', 'outlet', 'mount', 'partial', 'if', 'unless', 'let', 'with' ];
 
 function isComponentInvocation(node) {
   // TODO: super naive, needs to handle block params, paths, named args, etc
   return node.tag[0].toUpperCase() === node.tag[0];
 }
 
+function shouldAddInvocationLocation(node) {
+  // avoid infinite loop, don't rewrap our own hash
+  if (node.type === "SubExpression" && node.hash.pairs.find(p => p.key === "isTemplateInvocationInfo")) {
+    return false;
+  }
+
+  if (node.type === 'ElementNode' && !isComponentInvocation(node)) {
+    return false
+  }
+
+  let invokee = node.path ? node.path.original : node.tag;
+  if (BUILTINS.includes(invokee)) {
+    return false;
+  }
+
+  return true;
+}
+
 module.exports = function(env) {
   let { builders: b } = env.syntax;
 
   let transform = node => {
-    if (node.type === "SubExpression" && node.hash.pairs.find(p => p.key === "isTemplateInvocationInfo")) {
+    if (!shouldAddInvocationLocation(node)) {
       return;
     }
 
@@ -37,11 +56,7 @@ module.exports = function(env) {
       SubExpression: transform,
       MustacheStatement: transform,
       BlockStatement: transform,
-      ElementNode(node) {
-        if (isComponentInvocation(node)) {
-          transform(node);
-        }
-      }
+      ElementNode: transform,
     }
   };
 };

--- a/tests/integration/components/index-test.js
+++ b/tests/integration/components/index-test.js
@@ -9,6 +9,24 @@ import { helper } from '@ember/component/helper';
 module('Integration | Component | index', function(hooks) {
   setupRenderingTest(hooks);
 
+  module('AST transform', function() {
+    if (DEBUG) {
+      test('does not add named arguments to `yield` GH#9', async function(assert) {
+        assert.expect(1);
+
+        this.owner.register('template:components/x-foo', hbs('{{yield}}', { moduleName: 'app/templates/components/x-foo.hbs'}));
+        this.owner.register('helper:invoke-me', helper((params, hash) => {
+          let stack = getInvocationStack(hash);
+
+          assert.deepEqual(stack, [ 'app/templates/test.hbs @ L1:C10' ]);
+        }));
+
+        await render(hbs('{{#x-foo}}{{invoke-me}}{{/x-foo}}', { moduleName: 'app/templates/test.hbs' }));
+
+      });
+    }
+  });
+
   module('getInvocationLocation', function() {
     test('does not error', async function(assert) {
       this.owner.register('helper:invoke-me', helper((params, hash) => {


### PR DESCRIPTION
Some of these keywords trigger an error when an extra named argument is
added (e.g. `yield` errors for any named arguments other than `to`).

Closes #9.