### PR TITLE
Ensure simple property paths are not mutated.

### DIFF
--- a/addon/helpers/-template-invocation-info-is-component-or-helper.js
+++ b/addon/helpers/-template-invocation-info-is-component-or-helper.js
@@ -1,0 +1,36 @@
+import { getOwner } from '@ember/application';
+import Helper from '@ember/component/helper';
+
+// this is a hard coded value in glimmer-vm:
+// https://github.com/glimmerjs/glimmer-vm/blob/v0.38.0/packages/%40glimmer/runtime/lib/component/curried-component.ts#L6
+const CONTEXTUAL_COMPONENT_FLAG = 'CURRIED COMPONENT DEFINITION [id=6f00feb9-a0ef-4547-99ea-ac328f80acea]';
+
+export default Helper.extend({
+  compute([name, isBlockParam, value]) {
+    let isNamedArgument = name[0] === '@';
+    let isPath = name.includes('.');
+    let canBeHelper = !isBlockParam && !isPath && !isNamedArgument;
+    let valueIsObject = typeof value === 'object' && value !== null;
+
+    // TODO: handle block param paths
+
+    if (isNamedArgument) {
+      // TODO: what do we do here?
+    }
+
+    if (valueIsObject && value[CONTEXTUAL_COMPONENT_FLAG]) {
+      return true;
+    }
+
+    let owner = getOwner(this);
+    if (canBeHelper && owner.resolveRegistration(`helper:${name}`)) {
+      return true;
+    }
+
+    if (owner.resolveRegistration(`component:${name}`) || owner.resolveRegistration(`template:components/${name}`)) {
+      return true;
+    }
+
+    return false;
+  }
+});

--- a/app/helpers/-template-invocation-info-is-component-or-helper.js
+++ b/app/helpers/-template-invocation-info-is-component-or-helper.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-template-invocation-location/helpers/-template-invocation-info-is-component-or-helper';

--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -1,5 +1,5 @@
 const LOCATION_PROPERTY = 'debugTemplateInvocationSite'; // must match addon/index.js value
-const BUILTINS = ['yield', 'outlet', 'mount', 'partial', 'if', 'unless', 'let', 'with' ];
+const BUILTINS = ['yield', 'outlet', 'mount', 'partial', 'if', 'unless', 'let', 'with'];
 
 function isComponentInvocation(node) {
   // TODO: super naive, needs to handle block params, paths, named args, etc
@@ -8,12 +8,29 @@ function isComponentInvocation(node) {
 
 function shouldAddInvocationLocation(node) {
   // avoid infinite loop, don't rewrap our own hash
-  if (node.type === "SubExpression" && node.hash.pairs.find(p => p.key === "isTemplateInvocationInfo")) {
+  if (
+    node.type === 'SubExpression' &&
+    node.hash.pairs.find(p => p.key === 'isTemplateInvocationInfo')
+  ) {
+    return false;
+  }
+
+  if (
+    node.type === 'SubExpression' &&
+    node.path.original === '-template-invocation-info-is-component-or-helper'
+  ) {
+    return false;
+  }
+
+  if (
+    ['SubExpression', 'BlockStatement', 'MustacheStatement'].includes(node.type) &&
+    node.hash.pairs.find(p => p.key === 'debugTemplateInvocationSite')
+  ) {
     return false;
   }
 
   if (node.type === 'ElementNode' && !isComponentInvocation(node)) {
-    return false
+    return false;
   }
 
   let invokee = node.path ? node.path.original : node.tag;
@@ -27,6 +44,8 @@ function shouldAddInvocationLocation(node) {
 module.exports = function(env) {
   let { builders: b } = env.syntax;
 
+  let PROCESSED_NODES = new WeakSet();
+
   let transform = node => {
     if (!shouldAddInvocationLocation(node)) {
       return;
@@ -34,29 +53,76 @@ module.exports = function(env) {
 
     let moduleName = env.meta && env.meta.moduleName;
 
-    let locationInfo = b.sexpr("hash", [], b.hash([
-      b.pair('isTemplateInvocationInfo', b.boolean(true)),
-      b.pair('template', moduleName ? b.string(moduleName) : b.null()),
-      b.pair('line', b.number(node.loc.start.line)),
-      b.pair('column', b.number(node.loc.start.column)),
-      b.pair('parent', b.path(`@${LOCATION_PROPERTY}`)),
-    ]));
+    let locationInfo = b.sexpr(
+      'hash',
+      [],
+      b.hash([
+        b.pair('isTemplateInvocationInfo', b.boolean(true)),
+        b.pair('template', moduleName ? b.string(moduleName) : b.null()),
+        b.pair('line', b.number(node.loc.start.line)),
+        b.pair('column', b.number(node.loc.start.column)),
+        b.pair('parent', b.path(`@${LOCATION_PROPERTY}`)),
+      ])
+    );
 
-    if (node.type === "ElementNode") {
+    if (node.type === 'ElementNode') {
       node.attributes.push(b.attr(`@${LOCATION_PROPERTY}`, locationInfo));
     } else {
       node.hash.pairs.push(b.pair(LOCATION_PROPERTY, locationInfo));
     }
+
+    return node;
   };
 
   return {
-    name: "ast-transform",
+    name: 'ast-transform',
 
     visitor: {
       SubExpression: transform,
-      MustacheStatement: transform,
+      MustacheStatement(node) {
+        let hasArguments = node.params.length > 0 || node.hash.pairs.length > 0;
+
+        if (hasArguments) {
+          transform(node);
+        } else if (shouldAddInvocationLocation(node) && !PROCESSED_NODES.has(node)) {
+          // we are dealing with an ambiguous mustache invocation (we can't
+          // tell if its a property lookup, a helper invocation, a component
+          // invocation, etc) that isn't a built-in keyword
+          // in order to deal with this we rely on a runtime helper (`-is-component-or-helper`)
+          //
+          // the result is that a simple mustache like `{{foo}}` is rewritten
+          // to something like (whitespace added for clarity, but the result
+          // will not include additional whitespace):
+          //
+          // {{#if (-template-invocation-info-is-component-or-helper  foo)}}
+          //   {{foo debugTemplateInvocationSite=(hash ...)}}
+          // {{else}}
+          //   {{foo}}
+          // {{/if}}
+
+          let clonedNode = JSON.parse(JSON.stringify(node));
+
+          let conditional = b.block(
+            'if',
+            [
+              b.sexpr(
+                '-template-invocation-info-is-component-or-helper',
+                [b.string(node.path.original), b.boolean(false), b.path(node.path.original)],
+                null
+              ),
+            ],
+            null,
+            b.program([transform(clonedNode)]),
+            b.program([node])
+          );
+
+          PROCESSED_NODES.add(node);
+
+          return conditional;
+        }
+      },
       BlockStatement: transform,
       ElementNode: transform,
-    }
+    },
   };
 };

--- a/tests/integration/components/index-test.js
+++ b/tests/integration/components/index-test.js
@@ -40,6 +40,14 @@ module('Integration | Component | index', function(hooks) {
     });
 
     if (DEBUG) {
+      test('works within component template GH#11', async function(assert) {
+        this.owner.register('template:components/x-foo', hbs`{{@debugTemplateInvocationSite.template}} @ L{{@debugTemplateInvocationSite.line}}:C{{@debugTemplateInvocationSite.column}}`);
+
+        await render(hbs('some-stuff \n\n other stuff <div data-test>{{x-foo}}</div>', { moduleName: 'app/foo/bar.hbs' }));
+
+        assert.equal(this.element.querySelector('[data-test]').textContent, 'app/foo/bar.hbs @ L3:C28');
+      });
+
       test('allows helpers to access the template invocation location', async function(assert) {
         this.owner.register('helper:invoke-me', helper((params, hash) => {
           let location = getInvocationLocation(hash);

--- a/tests/integration/helpers/-template-invocation-info-is-component-or-helper-test.js
+++ b/tests/integration/helpers/-template-invocation-info-is-component-or-helper-test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { helper } from '@ember/component/helper';
+
+module('Integration | Helper | -template-invocation-info-is-component-or-helper', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('returns true when invoking a helper', async function(assert) {
+    this.owner.register('helper:foo', helper(function() {}));
+
+    await render(hbs`{{#if (-template-invocation-info-is-component-or-helper 'foo' false foo)}}helper found!{{/if}}`);
+
+    assert.equal(this.element.textContent, 'helper found!');
+  });
+
+  test('returns false when helper or component do not exist', async function(assert) {
+    await render(hbs`{{#if (-template-invocation-info-is-component-or-helper 'foo' false foo)}}helper found!{{/if}}`);
+
+    assert.equal(this.element.textContent, '');
+  });
+
+  test('returns true for contextual component', async function(assert) {
+    this.owner.register('template:components/x-foo', hbs``);
+
+    await render(hbs`
+      {{#let (component 'x-foo') as |thing|}}
+        {{#if (-template-invocation-info-is-component-or-helper 'thing' true thing)}}component found!{{/if}}
+      {{/let}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'component found!');
+  });
+});


### PR DESCRIPTION
Prior to this, the AST transform would add a named argument to _every_ mustache statement. This meant that simple/normal property lookups were getting rewritten from `{{foo}}` to `{{foo debugTemplateInvocationSite=(hash)}}`. When Ember sees a mustache statement that has arguments (positional or named) it **always** assumes it is a component invocation. Which means that when we rewrite `{{foo}}` from above, we have completely broken the ability to render any dynamic value in the template 😫.

The changes in this commit tweak things so that when we are dealing with an ambiguous mustache invocation (we can't tell if its a property lookup, a helper invocation, a component invocation, etc) that isn't a built-in keyword we use a runtime helper to determine if the path refers to a component or helper. This allows us to handle a simple mustache like `{{foo}}` by rewritting to something like (whitespace added for clarity, but the result will not include additional whitespace):

```hbs
{{#if (-template-invocation-info-is-component-or-helper  foo)}}
  {{foo debugTemplateInvocationSite=(hash ...)}}
{{else}}
  {{foo}}
{{/if}}
```

Fixes #11