### PR TITLE
Add proper dynamic angle bracket invocation detection.

### DIFF
--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -1,5 +1,5 @@
 const LOCATION_PROPERTY = 'debugTemplateInvocationSite'; // must match addon/index.js value
-const BUILTINS = ['yield', 'outlet', 'mount', 'partial', 'if', 'unless', 'let', 'with'];
+const BUILTINS = ['yield', 'outlet', 'mount', 'partial', 'if', 'unless', 'let', 'with', 'log', 'debugger'];
 
 function isComponentInvocation(node) {
   // TODO: super naive, needs to handle block params, paths, named args, etc

--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -1,12 +1,153 @@
 const LOCATION_PROPERTY = 'debugTemplateInvocationSite'; // must match addon/index.js value
 const BUILTINS = ['yield', 'outlet', 'mount', 'partial', 'if', 'unless', 'let', 'with', 'log', 'debugger'];
 
-function isComponentInvocation(node) {
-  // TODO: super naive, needs to handle block params, paths, named args, etc
-  return node.tag[0].toUpperCase() === node.tag[0];
+// sourced from https://github.com/ember-template-lint/ember-template-lint/blob/v1.5.3/lib/rules/internal/scope.js
+function getLocalName(node) {
+  switch (node.type) {
+    case 'ElementNode':
+      // unfortunately the ElementNode stores `tag` as a string
+      // if that changes in glimmer-vm this will need to be updated
+      return node.tag.split('.')[0];
+
+    case 'SubExpression':
+    case 'MustacheStatement':
+    case 'BlockStatement':
+      return node.path.parts[0];
+
+    case 'PathExpression':
+    default:
+      return node.parts[0];
+  }
 }
 
-function shouldAddInvocationLocation(node) {
+function getLocals(node) {
+  switch (node.type) {
+    case 'ElementNode':
+    case 'Program':
+    case 'Block':
+    case 'Template':
+      return node.blockParams;
+
+    case 'BlockStatement':
+      return node.program.blockParams;
+
+    default:
+      throw new Error(`Unknown frame type: ${node.type}`);
+  }
+}
+
+class Frame {
+  constructor(node) {
+    let locals = getLocals(node);
+
+    this.node = node;
+    this.locals = locals;
+    this.hasPartial = false;
+    this.usedLocals = {};
+
+    for (let i = 0; i < locals.length; i++) {
+      this.usedLocals[locals[i]] = false;
+    }
+  }
+
+  useLocal(name) {
+    if (name in this.usedLocals) {
+      this.usedLocals[name] = true;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  usePartial() {
+    this.hasPartial = true;
+  }
+
+  unusedLocals() {
+    if (!this.hasPartial && this.locals.length > 0) {
+      if (!this.usedLocals[this.locals[this.locals.length - 1]]) {
+        return this.locals[this.locals.length - 1];
+      }
+    } else {
+      return false;
+    }
+  }
+
+  isLocal(name) {
+    return this.locals.indexOf(name) !== -1;
+  }
+}
+
+class Scope {
+  constructor() {
+    this.frames = [];
+  }
+
+  pushFrame(node) {
+    this.frames.push(new Frame(node));
+  }
+
+  popFrame() {
+    this.frames.pop();
+  }
+
+  frameHasUnusedBlockParams() {
+    return this.frames[this.frames.length - 1].unusedLocals();
+  }
+
+  useLocal(node) {
+    let name = getLocalName(node);
+
+    for (let i = this.frames.length - 1; i >= 0; i--) {
+      if (this.frames[i].useLocal(name)) {
+        break;
+      }
+    }
+  }
+
+  usePartial() {
+    for (let i = this.frames.length - 1; i >= 0; i--) {
+      this.frames[i].usePartial();
+    }
+  }
+
+  isLocal(node) {
+    let name = getLocalName(node);
+
+    for (let i = this.frames.length - 1; i >= 0; i--) {
+      if (this.frames[i].isLocal(name)) {
+        return true;
+      }
+    }
+  }
+
+  get currentNode() {
+    let currentFrame = this.frames[this.frames.length - 1];
+
+    return currentFrame && currentFrame.node;
+  }
+}
+
+function isDynamicComponent(scope, element) {
+  let open = element.tag.charAt(0);
+
+  let isLocal = scope.isLocal(element);
+  let isNamedArgument = open === '@';
+  let isThisPath = element.tag.indexOf('this.') === 0;
+
+  return isLocal || isNamedArgument || isThisPath;
+}
+
+function isAngleBracketComponent(scope, element) {
+  let open = element.tag.charAt(0);
+  let isPath = element.tag.indexOf('.') > -1;
+
+  let isUpperCase = open === open.toUpperCase() && open !== open.toLowerCase();
+
+  return (isUpperCase && !isPath) || isDynamicComponent(scope, element);
+}
+
+function shouldAddInvocationLocation(scope, node) {
   // avoid infinite loop, don't rewrap our own hash
   if (
     node.type === 'SubExpression' &&
@@ -29,7 +170,7 @@ function shouldAddInvocationLocation(node) {
     return false;
   }
 
-  if (node.type === 'ElementNode' && !isComponentInvocation(node)) {
+  if (node.type === 'ElementNode' && !isAngleBracketComponent(scope, node)) {
     return false;
   }
 
@@ -45,9 +186,10 @@ module.exports = function(env) {
   let { builders: b } = env.syntax;
 
   let PROCESSED_NODES = new WeakSet();
+  let scope = new Scope();
 
   let transform = node => {
-    if (!shouldAddInvocationLocation(node)) {
+    if (!shouldAddInvocationLocation(scope, node)) {
       return;
     }
 
@@ -74,17 +216,41 @@ module.exports = function(env) {
     return node;
   };
 
+  function pushFrame(node) {
+    scope.pushFrame(node);
+  }
+
+  function popFrame() {
+    scope.popFrame();
+  }
+
   return {
     name: 'ast-transform',
 
     visitor: {
+      Program: {
+        enter: pushFrame,
+        exit: popFrame,
+      },
+      ElementNode: {
+        enter(node) {
+          transform(node);
+        },
+
+        keys: {
+          children: {
+            enter: pushFrame,
+            exit: popFrame,
+          },
+        },
+      },
       SubExpression: transform,
       MustacheStatement(node) {
         let hasArguments = node.params.length > 0 || node.hash.pairs.length > 0;
 
         if (hasArguments) {
           transform(node);
-        } else if (shouldAddInvocationLocation(node) && !PROCESSED_NODES.has(node)) {
+        } else if (shouldAddInvocationLocation(scope, node) && !PROCESSED_NODES.has(node)) {
           // we are dealing with an ambiguous mustache invocation (we can't
           // tell if its a property lookup, a helper invocation, a component
           // invocation, etc) that isn't a built-in keyword
@@ -101,13 +267,14 @@ module.exports = function(env) {
           // {{/if}}
 
           let clonedNode = JSON.parse(JSON.stringify(node));
+          let isBlockParam = scope.isLocal(node);
 
           let conditional = b.block(
             'if',
             [
               b.sexpr(
                 '-template-invocation-info-is-component-or-helper',
-                [b.string(node.path.original), b.boolean(false), b.path(node.path.original)],
+                [b.string(node.path.original), b.boolean(isBlockParam), b.path(node.path.original)],
                 null
               ),
             ],
@@ -122,7 +289,6 @@ module.exports = function(env) {
         }
       },
       BlockStatement: transform,
-      ElementNode: transform,
     },
   };
 };


### PR DESCRIPTION
Prior to this we assumed any element node that started with a capital
letter was a component invocation, but that left out a significant number
of scenarios (e.g. yielded contextual components).

This brings a block param scope tracking system so that we can be certain
that dynamic angle invocations are detected correctly.